### PR TITLE
💄 UI/스타일 파일 수정: VOC 필터 input outline 스타일 수정

### DIFF
--- a/src/assets/css/voc/VOCView.css
+++ b/src/assets/css/voc/VOCView.css
@@ -45,7 +45,8 @@
 .voc-excel-button,
 .voc-ai-button {
   background: #005950;
-  padding: 5px 10px;
+  padding: 3px 5px;
+  margin-bottom: 3px;
   border: none;
   color: #ffffff;
   cursor: pointer;
@@ -53,7 +54,7 @@
   display: flex;
   align-items: center;
   gap: 5px;
-  border-radius: 5px;
+  border-radius: 3px;
 }
 
 .voc-board-container {

--- a/src/assets/css/voc/VOCView.css
+++ b/src/assets/css/voc/VOCView.css
@@ -211,8 +211,10 @@
   margin-top: 8px;
   font-size: 13px;
   padding: 8px;
-  border: 1px solid #eaeaea;
-  border-radius: 4px;
+  border: 1px solid #898989;
+  border-radius: 3px;
+  outline: none;
+  font-family: Inter;
 }
 
 .voc-detail-actions {

--- a/src/assets/css/voc/VOCView.css
+++ b/src/assets/css/voc/VOCView.css
@@ -350,6 +350,7 @@
   align-items: center;
   gap: 5px;
   margin-top: 10px;
+  padding: 10px 0;
 }
 
 .voc-page-button {

--- a/src/assets/css/voc/VOCView.css
+++ b/src/assets/css/voc/VOCView.css
@@ -130,6 +130,10 @@
   cursor: pointer;
 }
 
+.voc-board-row.selected {
+  background-color: #E2E8F0;
+}
+
 .voc-board-row:hover {
   background-color: #f4f4f4;
 }

--- a/src/assets/css/voc/VOCView.css
+++ b/src/assets/css/voc/VOCView.css
@@ -120,13 +120,14 @@
 .voc-board-row {
   display: grid;
   grid-template-columns: 0.8fr 1.8fr 0.7fr 0.6fr 0.5fr 0.6fr 0.6fr 0.7fr 0.6fr 0.6fr;
-  padding: 10px 15px;
+  padding: 7px 14px;
   border-bottom: 1px solid #eaeaea;
   font-size: 11px;
   color: #333333;
   text-align: center;
   align-items: center;
   background-color: #ffffff;
+  cursor: pointer;
 }
 
 .voc-board-row:hover {

--- a/src/assets/css/voc/VOCView.css
+++ b/src/assets/css/voc/VOCView.css
@@ -211,7 +211,7 @@
   margin-top: 8px;
   font-size: 13px;
   padding: 8px;
-  border: 1px solid #898989;
+  border: 1px solid #bebcbc;
   border-radius: 3px;
   outline: none;
   font-family: Inter;

--- a/src/assets/css/voc/VOCView.css
+++ b/src/assets/css/voc/VOCView.css
@@ -198,7 +198,7 @@
   flex: 1;
   word-break: break-all; /* 긴 텍스트 줄바꿈 */
   white-space: pre-wrap; /* 줄바꿈 보존 */
-  text-align: left; /* 왼쪽 정렬 */
+  text-align: right; /* 왼쪽 정렬 */
 }
 
 .voc-detail-item .value_satisfaction, .value_voc_answer_status {

--- a/src/components/voc/VOCEditModule.vue
+++ b/src/components/voc/VOCEditModule.vue
@@ -45,12 +45,24 @@ const confirmAction = () => {
   z-index: 1000;
 }
 
+.voc-edit-modal-close {
+    position: absolute;
+    top: 15px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+  }
   
-  /* 모달 창 스타일 */
-  .voc-edit-modal-container {
+  
+/* 모달 창 스타일 */
+.voc-edit-modal-container {
   background-color: #ffffff;
   width: 500px;
-  height: 200px;
+  min-height: 200px; /* 최소 높이를 설정하여 내용이 많을 경우 높이가 늘어나도록 함 */
+  max-width: 90%; /* 화면 크기에 따라 모달 너비가 너무 커지지 않도록 제한 */
+  height: auto; /* 내용에 맞게 자동으로 높이가 조정되도록 설정 */
   border-radius: 10px;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
   padding: 20px;
@@ -83,48 +95,44 @@ const confirmAction = () => {
     border-bottom-right-radius: 10px; /* 모서리 둥글게 */
   }
 }
-
-  
-  /* 닫기 버튼 */
-  .voc-edit-modal-close {
-    position: absolute;
-    top: 15px;
-    right: 10px;
-    background: none;
-    border: none;
-    font-size: 20px;
-    cursor: pointer;
-  }
-  
-  /* 제목 스타일 */
-  .voc-edit-modal-title {
-    margin-top: 35px;
+.voc-edit-modal-title {
+    margin-top: 25px;
     font-size: 23px;
     color: #193325; /* 제목 글자 색 */
   }
-  
-  /* 버튼 컨테이너 */
-  .voc-edit-modal-actions {
-    display: flex;
-    justify-content: center; 
-    margin-top: 40px;
-    gap: 70px;
-    
-    .voc-edit-modal-button {
-      background-color: #145f58;
-      color: #ffffff;
-      border: none;
-      border-radius: 10px;
-      width: 90px;
-      height: 32px;
-      cursor: pointer;
-      font-size: 16px;
-      box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-  
-      &:hover {
-        background-color: #124c47;
-      }
-    }
+
+
+.voc-edit-modal-message {
+    margin-top: 15px;
+    font-size: 17px;
+    color: #000000; /* 제목 글자 색 */
   }
+  
+/* 버튼 컨테이너 */
+.voc-edit-modal-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px; /* 높이를 조정하여 내용에 맞게 배치 */
+  gap: 70px; /* 버튼 간격을 좁힘 */
+}
+
+/* 버튼 스타일 */
+.voc-edit-modal-button {
+  background-color: #145f58;
+  color: #ffffff;
+  border: none;
+  border-radius: 10px;
+  width: 90px;
+  height: 32px;
+  cursor: pointer;
+  font-size: 16px;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  text-align: center; /* 버튼 텍스트 정렬 */
+  
+  &:hover {
+    background-color: #124c47;
+  }
+}
+
   </style>
   

--- a/src/components/voc/VOCFilter.vue
+++ b/src/components/voc/VOCFilter.vue
@@ -183,6 +183,7 @@ const reset = () => {
 }
 
 .voc-filter-input {
+  outline: none;
   flex: 1;
   padding: 5px 5px;
   font-size: 11px;
@@ -198,6 +199,7 @@ const reset = () => {
 }
 
 .voc-date-input {
+  outline: none;
   width: calc(50% - 8px);
   min-width: 0;
 }

--- a/src/components/voc/VOCRegisterModule.vue
+++ b/src/components/voc/VOCRegisterModule.vue
@@ -46,11 +46,24 @@ const confirmAction = () => {
 }
 
   
-  /* 모달 창 스타일 */
-  .voc-register-modal-container {
+.voc-register-modal-close {
+    position: absolute;
+    top: 15px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+  }
+  
+  
+/* 모달 창 스타일 */
+.voc-register-modal-container {
   background-color: #ffffff;
   width: 500px;
-  height: 200px;
+  min-height: 200px; /* 최소 높이를 설정하여 내용이 많을 경우 높이가 늘어나도록 함 */
+  max-width: 90%; /* 화면 크기에 따라 모달 너비가 너무 커지지 않도록 제한 */
+  height: auto; /* 내용에 맞게 자동으로 높이가 조정되도록 설정 */
   border-radius: 10px;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
   padding: 20px;
@@ -83,48 +96,44 @@ const confirmAction = () => {
     border-bottom-right-radius: 10px; /* 모서리 둥글게 */
   }
 }
-
-  
-  /* 닫기 버튼 */
-  .voc-register-modal-close {
-    position: absolute;
-    top: 15px;
-    right: 10px;
-    background: none;
-    border: none;
-    font-size: 20px;
-    cursor: pointer;
-  }
-  
-  /* 제목 스타일 */
-  .voc-register-modal-title {
-    margin-top: 35px;
+.voc-register-modal-title {
+    margin-top: 25px;
     font-size: 23px;
     color: #193325; /* 제목 글자 색 */
   }
-  
-  /* 버튼 컨테이너 */
-  .voc-register-modal-actions {
-    display: flex;
-    justify-content: center; 
-    margin-top: 40px;
-    gap: 70px;
-    
-    .voc-register-modal-button {
-      background-color: #145f58;
-      color: #ffffff;
-      border: none;
-      border-radius: 10px;
-      width: 90px;
-      height: 32px;
-      cursor: pointer;
-      font-size: 16px;
-      box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-  
-      &:hover {
-        background-color: #124c47;
-      }
-    }
+
+
+.voc-register-modal-message {
+    margin-top: 15px;
+    font-size: 17px;
+    color: #000000; /* 제목 글자 색 */
   }
+  
+/* 버튼 컨테이너 */
+.voc-register-modal-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px; /* 높이를 조정하여 내용에 맞게 배치 */
+  gap: 70px; /* 버튼 간격을 좁힘 */
+}
+
+/* 버튼 스타일 */
+.voc-register-modal-button {
+  background-color: #145f58;
+  color: #ffffff;
+  border: none;
+  border-radius: 10px;
+  width: 90px;
+  height: 32px;
+  cursor: pointer;
+  font-size: 16px;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  text-align: center; /* 버튼 텍스트 정렬 */
+  
+  &:hover {
+    background-color: #124c47;
+  }
+}
+
   </style>
   

--- a/src/views/voc/VocView.vue
+++ b/src/views/voc/VocView.vue
@@ -4,7 +4,7 @@
     <div class="voc-content-container" :class="{ 'single-view': isSingleView }">
       <VOCFilter @search="handleSearch" @reset="handleReset" />
       <div class="voc-actions">
-        <div class="voc-count">등록된 VOC <span class="voc-length">{{ totalCount }}</span>개</div>
+        <div class="voc-count">등록된 VOC <span class="voc-length">{{ formatNumber(totalCount) }}</span>개</div>
         <div class="voc-button-group">
           <button class="voc-excel-button" @click="handleExcelDownload">
             <img src="@/assets/icons/download.svg" alt="다운로드">
@@ -333,6 +333,12 @@ const camelToSnake = (obj) => {
 const showSingleVoc = () => {
   isSingleView.value = true;
   console.log('showSingleVoc called: isSingleView =', isSingleView.value);
+};
+
+
+const formatNumber = (number) => {
+  if (!number) return '0';
+  return number.toLocaleString('ko-KR');
 };
 
 const hideSingleVoc = () => {

--- a/src/views/voc/VocView.vue
+++ b/src/views/voc/VocView.vue
@@ -235,6 +235,13 @@
               <button
                 v-if="isEditingAnswer"
                 class="voc-answer-complete-button"
+                @click="cancelEditing"
+              >
+                취소
+              </button>
+              <button
+                v-if="isEditingAnswer"
+                class="voc-answer-complete-button"
                 @click="confirmAction"
               >
                 완료
@@ -439,6 +446,10 @@ const translateMemberType = (type) => {
   }
 };
 
+const cancelEditing = () => {
+  isEditingAnswer.value = false;  
+  editAnswerContent.value = selectedVOC.value.voc_answer_content; 
+};
 
 const formatDateFromArray = (dateArray) => {
   if (!Array.isArray(dateArray) || dateArray.length < 5) return '';
@@ -509,11 +520,16 @@ const startRegisteringAnswer = () => {
   editAnswerContent.value = '';
 };
 
+
 const confirmAction = () => {
   if (!editAnswerContent.value.trim()) {
     alert('답변 내용을 입력해주세요.');
     return;
   }
+
+
+
+
 
   if (!selectedVOC.value.voc_answer_code) {
     isRegisterModalOpen.value = true;

--- a/src/views/voc/VocView.vue
+++ b/src/views/voc/VocView.vue
@@ -510,6 +510,7 @@ const closeRegisterModal = () => {
   isRegisterModalOpen.value = false;
 };
 
+
 const startEditingAnswer = () => {
     isEditingAnswer.value = true;
     editAnswerContent.value = selectedVOC.value?.voc_answer_content || '';

--- a/src/views/voc/VocView.vue
+++ b/src/views/voc/VocView.vue
@@ -169,7 +169,7 @@
             </div>
             <div class="voc-detail-item">
               <span class="label">VOC 내용</span>
-              <span class="value">{{ selectedVOC.voc_content }}</span>
+              <span class="value" style="width: 200px;">{{ selectedVOC.voc_content }}</span>
             </div>
             <div class="voc-detail-item">
               <span class="label">카테고리</span>
@@ -209,7 +209,7 @@
             </div>
             <div class="voc-detail-item">
               <span class="label">VOC 답변</span>
-              <span v-if="!isEditingAnswer" class="value">{{ selectedVOC.voc_answer_content || '답변이 등록되지 않았습니다.' }}</span>
+              <span v-if="!isEditingAnswer" class="value" style="width: 200px;">{{ selectedVOC.voc_answer_content || '답변이 등록되지 않았습니다.' }}</span>
               <textarea
                 v-else
                 v-model="editAnswerContent"

--- a/src/views/voc/VocView.vue
+++ b/src/views/voc/VocView.vue
@@ -127,7 +127,7 @@
               <div class="voc-board-row-number">{{ voc.voc_code.slice(0, 10) }}...</div>
               <div class="voc-board-row-content">{{ voc.voc_content }}</div>
               <div class="voc-board-row-category">{{ voc.voc_category_name }}</div>
-              <div class="voc-board-row-type">{{ voc.member_type }}</div>
+              <div class="voc-board-row-type">{{ translateMemberType(voc.member_type) }}</div>
               <div class="voc-board-row-name">{{ maskName(voc.member_name) }}</div>
               <div class="voc-board-row-code">{{ voc.member_code }}</div>
               <div class="voc-board-row-manager">{{ voc.admin_name || '-' }}</div>
@@ -177,7 +177,7 @@
             </div>
             <div class="voc-detail-item">
               <span class="label">고객 유형</span>
-              <span class="value">{{ selectedVOC.member_type }}</span>
+              <span class="value">{{ translateMemberType(selectedVOC.member_type) }}</span>
             </div>
             <div class="voc-detail-item">
               <span class="label">고객명</span>
@@ -429,6 +429,16 @@ const handleExcelDownload = async () => {
   }
 };
 
+const translateMemberType = (type) => {
+  if (type === 'STUDENT') {
+    return '학생';
+  } else if (type === 'TUTOR') {
+    return '강사';
+  } else {
+    return type; // 예외 처리
+  }
+};
+
 
 const formatDateFromArray = (dateArray) => {
   if (!Array.isArray(dateArray) || dateArray.length < 5) return '';
@@ -474,6 +484,7 @@ const showVOCDetail = async (voc) => {
     }
   }
 };
+
 
 const closeVOCDetail = () => {
   selectedVOC.value = null;


### PR DESCRIPTION
- 제목 : feat: 💄 UI/스타일 파일 수정: VOC 필터 input outline 스타일 수정

## 🔘Part
- [x] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
 -VOC 답변 선택 했을때 생기는 아웃라인 없애기 ✅
,-VOC 답변 수정 모달 CSS 수정하기,    ✅
- 완료 옆에 수정 취소 버튼이 있어할듯,  ✅
- 좌측/우측 정렬 하나만 하쇼 ✅
- 컨테이너랑 페이지네이션이랑 위아래 padding 추가하기  ✅
- 등록된 VOC 전체 수 천단위 , 찍기 ✅
- 상세조회: 선택된 강의 행 색 수정하기(E2E8F0) ✅
- 행간격줄이기 ✅

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/f87206e3-e761-487c-8b78-d49b48b9ed47)

<br/>

## 🔧 앞으로의 과제

- 단건조회 후 답변 수정하고 그상태로 다른 건 클릭하면 수정하던상태 그대로 이동됨 . 
그상태에서 만약 수정 완료 누르면 마지막에 선택된 VOC의 답변이 수정됨,  -> 수정

  <br/>
